### PR TITLE
Fix to 'get' command to allow url manipulation

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,12 @@
 Change Log
 ==========
 
+?.?.?
+-----
+
+- Fix to allow the 'get' command to use the temporary environment
+  variables to modify the url for acquiring the content.
+
 1.1.1
 -----
 

--- a/nebu/cli/main.py
+++ b/nebu/cli/main.py
@@ -96,8 +96,14 @@ def cli(verbose):
 @click.argument('col_version', default='latest')
 def get(col_id, col_version, output_dir):
     """download and expand the completezip to the current working directory"""
-    url = 'http://legacy.cnx.org/content/{}/{}/complete'.format(
-        col_id, col_version)
+    # FIXME We need to be able to build urls to multiple services.
+    #       For now we'll use an environment variable
+    scheme = os.environ.get('XXX_SCHEME', 'https')
+    host = os.environ.get('XXX_HOST', 'cnx.org')
+    sep = len(host.split('.')) > 2 and '-' or '.'
+    url = '{}://legacy{}{}/content/{}/{}/complete'.format(
+        scheme, sep, host, col_id, col_version)
+    # / FIXME
 
     tmp_dir = Path(tempfile.mkdtemp())
     zip_filepath = tmp_dir / 'complete.zip'

--- a/nebu/tests/cli/test_main.py
+++ b/nebu/tests/cli/test_main.py
@@ -160,7 +160,7 @@ def test_main_with_verbosity(invoker):
 
 def test_get_cmd(datadir, tmpcwd, requests_mocker, invoker):
     col_id = 'col11405'
-    url = 'http://legacy.cnx.org/content/{}/latest/complete'.format(col_id)
+    url = 'https://legacy.cnx.org/content/{}/latest/complete'.format(col_id)
 
     complete_zip = datadir / 'complete.zip'
     content_size = complete_zip.stat().st_size
@@ -200,7 +200,7 @@ def test_get_cmd_with_existing_output_dir(tmpcwd, capsys, invoker):
 
 def test_get_cmd_with_failed_request(requests_mocker, invoker):
     col_id = 'col00000'
-    url = 'http://legacy.cnx.org/content/{}/latest/complete'.format(col_id)
+    url = 'https://legacy.cnx.org/content/{}/latest/complete'.format(col_id)
 
     requests_mocker.register_uri('GET', url, status_code=404)
 


### PR DESCRIPTION
This allows the 'get' command to use the same temporary environment
variables to manipulate the url, thus modifying the origin of the data.

Fixes #11 