### PR TITLE
Add a '--version' option to show the currently installed version

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,11 @@
 Change Log
 ==========
 
+?.?.?
+-----
+
+- Add a '--version' option to show the currently installed version.
+
 1.2.0
 -----
 

--- a/nebu/cli/main.py
+++ b/nebu/cli/main.py
@@ -17,6 +17,7 @@ from litezip import (
     validate_litezip,
 )
 
+from nebu import __version__
 from ..logger import configure_logging, logger
 
 
@@ -84,8 +85,19 @@ def set_verbosity(verbose):
     configure_logging(config)
 
 
+def _version_callback(ctx, param, value):
+    if not value or ctx.resilient_parsing:
+        return
+    working_version = __version__
+    click.echo('Nebuchadnezzar {}'.format(working_version))
+    ctx.exit()
+
+
 @click.group()
 @click.option('-v', '--verbose', is_flag=True, help='enable verbosity')
+@click.option('--version', callback=_version_callback, is_flag=True,
+              expose_value=False, is_eager=True,
+              help='Show the version and exit')
 def cli(verbose):
     set_verbosity(verbose)
 

--- a/nebu/tests/cli/test_main.py
+++ b/nebu/tests/cli/test_main.py
@@ -158,6 +158,21 @@ def test_main_with_verbosity(invoker):
     assert "ErrOr" in out
 
 
+def test_for_version(monkeypatch, invoker):
+    version = 'X.Y.Z'
+
+    import nebu.cli.main
+    monkeypatch.setattr(nebu.cli.main, '__version__', version)
+
+    from nebu.cli.main import cli
+    args = ['--version']
+    result = invoker(cli, args)
+    assert result.exit_code == 0
+
+    expected_output = 'Nebuchadnezzar {}\n'.format(version)
+    assert result.output == expected_output
+
+
 def test_get_cmd(datadir, tmpcwd, requests_mocker, invoker):
     col_id = 'col11405'
     url = 'https://legacy.cnx.org/content/{}/latest/complete'.format(col_id)

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1,3 +1,5 @@
 click
 cnx-litezip
+pip
 requests
+setuptools


### PR DESCRIPTION
Addresses part of #10. This specifically attempts to answer the question, "What version am I using?"

```sh
> neb --version
Nebuchadnezzar version 1.2.0+1.g16a1bfa
```