### PR TITLE
Save a backup file for config-atom command

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,11 @@
 Change Log
 ==========
 
+?.X.?
+-----
+
+- Modify 'config-atom' command to make a backup of the existing config.
+
 1.3.0
 -----
 

--- a/nebu/cli/main.py
+++ b/nebu/cli/main.py
@@ -281,7 +281,10 @@ def publish(content_dir, publication_message):
         sys.exit(1)
 
 
-_comfirmation_prompt = 'This could overwrite your config... continue?'
+_confirmation_prompt = (
+    'A backup of your atom-config will be created.\n'
+    'However, this will overwrite your config... continue?'
+)
 _ATOM_CONFIG_TEMPLATE = """\
 "*":
   core:
@@ -318,11 +321,15 @@ _ATOM_CONFIG_TEMPLATE = """\
 
 
 @cli.command(name='config-atom')
-@click.confirmation_option(prompt=_comfirmation_prompt)
+@click.confirmation_option(prompt=_confirmation_prompt)
 def config_atom():
     filepath = Path.home() / '.atom/config.cson'
     if not filepath.parent.exists():
         filepath.parent.mkdir()
+    if filepath.exists():
+        backup_filepath = filepath.parent / 'config.cson.bak'
+        filepath.rename(backup_filepath)
+        logger.info("Wrote backup to {}".format(backup_filepath.resolve()))
 
     cnxml_jing_rng = pkg_resources.resource_filename(
         'cnxml',

--- a/nebu/tests/cli/test_main.py
+++ b/nebu/tests/cli/test_main.py
@@ -464,6 +464,7 @@ class TestConfigAtomCmd:
 
     def test_with_exiting_config(self, monkeypatch, invoker):
         filepath = self.tmpdir / '.atom/config.cson'
+        backup_filepath = filepath.parent / (filepath.name + '.bak')
         filepath.parent.mkdir()
         with filepath.open('w') as fb:
             fb.write('baz')
@@ -472,3 +473,27 @@ class TestConfigAtomCmd:
         args = ['config-atom', '--yes']
         result = invoker(cli, args)
         self.check(result)
+
+        # Check for backup file creation
+        assert 'Wrote backup to ' in result.output
+        with backup_filepath.open('r') as fb:
+            assert 'baz' in fb.read()
+
+    def test_with_exiting_config_and_backup(self, monkeypatch, invoker):
+        filepath = self.tmpdir / '.atom/config.cson'
+        backup_filepath = filepath.parent / (filepath.name + '.bak')
+        filepath.parent.mkdir()
+        with filepath.open('w') as fb:
+            fb.write('baz')
+        with backup_filepath.open('w') as fb:
+            fb.write('raz')
+
+        from nebu.cli.main import cli
+        args = ['config-atom', '--yes']
+        result = invoker(cli, args)
+        self.check(result)
+
+        # Check for backup file is overwritten
+        assert 'Wrote backup to ' in result.output
+        with backup_filepath.open('r') as fb:
+            assert 'baz' in fb.read()


### PR DESCRIPTION
The adjustment adds some to to the output. This tells the user that a backup will be made and where the backup file has been written.

```
$ neb config-atom
A backup of your atom-config will be created.
However, this will overwrite your config... continue? [y/N]: y
Wrote backup to /Users/pumazi/.atom/config.cson.bak
Wrote /Users/pumazi/.atom/config.cson
```