### PR TITLE
Touchup coverage procedures

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,5 +4,6 @@
 omit =
   *nebu/_version.py
   *nebu/__init__.py
+  *nebu/tests/*
 exclude_lines =
   pragma: no cover

--- a/Makefile
+++ b/Makefile
@@ -83,7 +83,7 @@ help-test :
 	@echo "    (see also setup.cfg's pytest configuration)"
 
 test : $(STATEDIR)/env/pyvenv.cfg
-	$(BINDIR)/python -m pytest --cov=nebu $(TEST_EXTRA_ARGS) $(TEST)
+	$(BINDIR)/python -m pytest --cov=nebu --cov-report=html --cov-report=term $(TEST_EXTRA_ARGS) $(TEST)
 
 # /Test
 


### PR DESCRIPTION
This change set omits the testing modules from the coverage and automates the coverage report creation by adding options to the test running command line.