### PR TITLE
Implement list-of-valid-environments command

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,11 @@
 Change Log
 ==========
 
+?X.Y.Z
+-----
+
+- Add `list` command, to list individual environments defined in configuration.
+
 2.0.1
 -----
 

--- a/nebu/cli/main.py
+++ b/nebu/cli/main.py
@@ -219,6 +219,20 @@ def validate(content_dir):
         logger.info("We've got problems... :(")
 
 
+@cli.command()
+@click.pass_context
+def list(context):
+    """List of valid environment names from config.
+
+    Names are required for get and publish"""
+    envs = context.obj['settings']['environs']
+    lines = []
+    for env, val in envs.items():
+        lines.append('{}\t {url}'.format(env, **val))
+    lines.sort()
+    logger.info('\n'.join(lines))
+
+
 def _publish(base_url, struct, message):
     """Publish the struct to a repository"""
     collection_id = struct[0].id

--- a/nebu/cli/main.py
+++ b/nebu/cli/main.py
@@ -219,9 +219,9 @@ def validate(content_dir):
         logger.info("We've got problems... :(")
 
 
-@cli.command()
+@cli.command(name='list')
 @click.pass_context
-def list(context):
+def environments(context):
     """List of valid environment names from config.
 
     Names are required for get and publish"""

--- a/nebu/tests/cli/test_main.py
+++ b/nebu/tests/cli/test_main.py
@@ -210,6 +210,17 @@ def test_for_version(monkeypatch, invoker):
     assert result.output == expected_output
 
 
+def test_for_list(monkeypatch, invoker):
+
+    from nebu.cli.main import cli
+    args = ['list']
+    result = invoker(cli, args)
+    assert result.exit_code == 0
+
+    expected_output = 'test-env\t https://cnx.org\n'
+    assert result.output == expected_output
+
+
 class TestGetCmd:
 
     def test(self, datadir, tmpcwd, requests_mocker, invoker):


### PR DESCRIPTION
Now that `get` and `publish` require an `env` argument, provide a way to list valid environment tags