### PR TITLE
update error messaging when trying to get into existing directory

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,13 @@
 Change Log
 ==========
 
+2.0.1
+-----
+
+- Clarify the error message produced when attempting to get content
+  that is already downloaded. This clarification is for when ``neb get``
+  would colide with an existing directory of the same name.
+
 2.0.0
 -----
 

--- a/nebu/cli/main.py
+++ b/nebu/cli/main.py
@@ -65,7 +65,7 @@ class ExistingOutputDir(click.ClickException):
     exit_code = 3
 
     def __init__(self, output_dir):
-        message = "output directory cannot exist:  {}".format(output_dir)
+        message = "directory already exists:  {}".format(output_dir)
         super(ExistingOutputDir, self).__init__(message)
 
 

--- a/nebu/tests/cli/test_main.py
+++ b/nebu/tests/cli/test_main.py
@@ -251,7 +251,7 @@ class TestGetCmd:
 
         assert result.exit_code == 3
 
-        assert 'output directory cannot exist:' in result.output
+        assert 'directory already exists:' in result.output
 
     def test_with_failed_request(self, requests_mocker, invoker):
         col_id = 'col00000'


### PR DESCRIPTION
Slight clarification to error message when trying to `neb get` into an existing directory with the same name. Discussed with @Bkblodget. 