### PR TITLE
Change the Press api route from /api/v3/publish to /api/publish-litezip

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,11 @@
 Change Log
 ==========
 
+3.0.0
+-----
+
+- Adjusted the publication api point in response to the api change in Press.
+
 2.1.0
 -----
 

--- a/nebu/cli/main.py
+++ b/nebu/cli/main.py
@@ -256,11 +256,12 @@ def _publish(base_url, struct, message):
             # TODO Include resource files
 
     # Send it!
-    url = '{}/api/v3/publish'.format(base_url)
+    url = '{}/api/publish-litezip'.format(base_url)
     # FIXME We don't have nor want explicit setting of the publisher.
     #       The publisher will come through as part of the authentication
     #       information, which will be in a later implementation.
     #       For now, pull it out of a environment variable.
+    headers = {'X-API-Version': '3'}
     data = {
         'publisher': os.environ.get('XXX_PUBLISHER', 'OpenStaxCollege'),
         'message': message,
@@ -268,7 +269,7 @@ def _publish(base_url, struct, message):
     files = {
         'file': ('contents.zip', zip_file.open('rb'),),
     }
-    resp = requests.post(url, data=data, files=files)
+    resp = requests.post(url, data=data, files=files, headers=headers)
 
     # Clean up!
     zip_file.unlink()

--- a/nebu/tests/cli/test_main.py
+++ b/nebu/tests/cli/test_main.py
@@ -338,7 +338,7 @@ class TestPublishCmd:
         monkeypatch.setenv('XXX_PUBLISHER', publisher)
 
         # Mock the publishing request
-        url = 'https://cnx.org/api/v3/publish'
+        url = 'https://cnx.org/api/publish-litezip'
         resp_callback = ResponseCallback(COLLECTION_PUBLISH_PRESS_RESP_DATA)
         requests_mocker.register_uri('POST', url, status_code=200,
                                      text=resp_callback)
@@ -391,7 +391,7 @@ class TestPublishCmd:
         monkeypatch.setenv('XXX_PUBLISHER', publisher)
 
         # Mock the publishing request
-        url = 'https://cnx.org/api/v3/publish'
+        url = 'https://cnx.org/api/publish-litezip'
         resp_callback = ResponseCallback(COLLECTION_PUBLISH_PRESS_RESP_DATA)
         requests_mocker.register_uri('POST', url, status_code=200,
                                      text=resp_callback)
@@ -466,7 +466,7 @@ class TestPublishCmd:
         monkeypatch.setenv('XXX_PUBLISHER', publisher)
 
         # Mock the publishing request
-        url = 'https://cnx.org/api/v3/publish'
+        url = 'https://cnx.org/api/publish-litezip'
         requests_mocker.register_uri('POST', url, status_code=400,
                                      text='400')
 


### PR DESCRIPTION
Change /api/v3/publish to /api/publish-litezip, because the OpenStax developer community is favoring api versioning by HTTP header. This doesn't actually go so far as to add the version http header, but that's not important at the moment. This adjustment is to make this major change prior to initial release.