### PR TITLE
Fix the 'get' command to request a specific version of the completezip

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,14 @@
 Change Log
 ==========
 
+?.?.?
+-----
+
+- Fix the 'get' command to request a specific version of the completezip,
+  rather than rely on the 'latest' specifier, which has the issue of
+  requesting a cached completezip.
+  See https://github.com/Connexions/nebuchadnezzar/issues/44
+
 3.0.1
 -----
 

--- a/nebu/cli/main.py
+++ b/nebu/cli/main.py
@@ -133,16 +133,7 @@ def cli(ctx, verbose):
 @click.pass_context
 def get(ctx, env, col_id, col_version, output_dir):
     """download and expand the completezip to the current working directory"""
-    base_url = get_base_url(ctx, env)
-    parsed_url = urlparse(base_url)
-    sep = len(parsed_url.netloc.split('.')) > 2 and '-' or '.'
-    url_parts = [
-        parsed_url.scheme,
-        'legacy{}{}'.format(sep, parsed_url.netloc),
-    ] + list(parsed_url[2:])
-    base_url = urlunparse(url_parts)
-    url = '{}/content/{}/{}/complete'.format(base_url, col_id, col_version)
-
+    # Determine the output directory
     tmp_dir = Path(tempfile.mkdtemp())
     zip_filepath = tmp_dir / 'complete.zip'
     if output_dir is None:
@@ -152,6 +143,29 @@ def get(ctx, env, col_id, col_version, output_dir):
 
     if output_dir.exists():
         raise ExistingOutputDir(output_dir)
+
+    # Build the base url
+    base_url = get_base_url(ctx, env)
+    parsed_url = urlparse(base_url)
+    sep = len(parsed_url.netloc.split('.')) > 2 and '-' or '.'
+    url_parts = [
+        parsed_url.scheme,
+        'legacy{}{}'.format(sep, parsed_url.netloc),
+    ] + list(parsed_url[2:])
+    base_url = urlunparse(url_parts)
+
+    if col_version == 'latest':
+        # See https://github.com/Connexions/nebuchadnezzar/issues/44
+        # Acquire the specific version of the completezip
+        logger.debug("Requesting a specific version for {}".format(col_id))
+        url = '{}/content/{}/latest/getVersion'.format(base_url, col_id)
+        resp = requests.get(url)
+        if resp.status_code >= 400:
+            raise MissingContent(col_id, col_version)
+        col_version = resp.text.strip()
+
+    # Build the url to the completezip
+    url = '{}/content/{}/{}/complete'.format(base_url, col_id, col_version)
 
     logger.debug('Request sent to {} ...'.format(url))
     resp = requests.get(url, stream=True)


### PR DESCRIPTION
This no longer relies on the 'latest' specifier, which has the issue of
requesting a cached completezip.

Addresses #44 and #46 