### PR TITLE
Request the 'head' version when getting content

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,13 @@
 Change Log
 ==========
 
+?.?.?
+-----
+
+- Fix 'get' for 'latest' content by requesting the 'head' version. This will
+  give us the latest publication regardless of the public state of the
+  content.
+
 3.1.0
 -----
 


### PR DESCRIPTION
Fix 'get' for 'latest' content by requesting the 'head' version. This will give us the latest publication regardless of the public state of the content.

This depends on Connexions/cnx-press#110

## What this means to the users

When users enter ``neb get col11962``, two requests are made (same as before):
 1) request for `/api/collections/col11962/head`, which gives us a url to the most recent published version.
 2) request for the completezip

You can still request the 'latest' by using ``neb get col11962 latest`` if you'd like.