### PR TITLE
Add a skip-validation option flag to the publish command

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,7 @@ Change Log
 -----
 
 - Split the cli module into submodules, one for each subcommmand.
+- Add a skip-validation option flag to the publish command.
 
 4.0.0
 -----

--- a/nebu/cli/publish.py
+++ b/nebu/cli/publish.py
@@ -85,20 +85,21 @@ def _publish(base_url, struct, message):
 @click.argument('content_dir',
                 type=click.Path(exists=True, file_okay=False))
 @click.argument('publication_message', type=str)
+@click.option('--skip-validation', is_flag=True)
 @click.pass_context
-def publish(ctx, env, content_dir, publication_message):
+def publish(ctx, env, content_dir, publication_message, skip_validation):
     base_url = get_base_url(ctx, env)
 
     content_dir = Path(content_dir).resolve()
     struct = parse_litezip(content_dir)
 
-    if is_valid(struct):
-        has_published = _publish(base_url, struct, publication_message)
-        if has_published:
-            logger.info("Great work!!! =D")
-        else:
-            logger.info("Stop the Press!!! =()")
-            sys.exit(1)
-    else:
+    if not skip_validation and not is_valid(struct):
         logger.info("We've got problems... :(")
+        sys.exit(1)
+
+    has_published = _publish(base_url, struct, publication_message)
+    if has_published:
+        logger.info("Great work!!! =D")
+    else:
+        logger.info("Stop the Press!!! =()")
         sys.exit(1)


### PR DESCRIPTION
Since we are using atom to do validation, this option simply allows us to skip over the validation when publishing. With this option enabled, you should see a significant speed increase. I'd guess this will specifically help in testing and development. 

Example usage, `neb publish --skip-validation qa . "foo"`