### PR TITLE
Fix FileNotFoundError when ~/.config doesn't exist

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,14 @@
 Change Log
 ==========
 
+5.0.1
+-----
+
+- Fix ``FileNotFoundError`` raised on on user's first run of Nebuchadnezzar.
+  This was caused by the parent directory not existing, so the default
+  behavior of writing the default config failed with this error.
+  See https://github.com/Connexions/nebuchadnezzar/issues/66
+
 5.0.0
 -----
 

--- a/nebu/config.py
+++ b/nebu/config.py
@@ -28,6 +28,7 @@ url = https://cnx.org
 
 def _write_default_config_file():
     """Writes the default config file to the filesystem."""
+    CONFIG_FILE_LOC.parent.mkdir(exist_ok=True)  # create ~/.config
     with CONFIG_FILE_LOC.open('w') as fb:
         fb.write(INITIAL_DEFAULT_CONFIG)
 
@@ -82,7 +83,7 @@ def prepare():
     # Get the settings
     settings = discover_settings()
 
-    def closer():
+    def closer():  # pragma: no cover
         pass
 
     return {'closer': closer, 'settings': settings}

--- a/nebu/tests/test_config.py
+++ b/nebu/tests/test_config.py
@@ -80,6 +80,27 @@ class TestDiscoverSettings:
         with loc.open('r') as fb:
             assert fb.read() == INITIAL_DEFAULT_CONFIG
 
+    def test_missing_config_and_parent_directory(self, tmpdir, monkeypatch):
+        loc = Path(str(tmpdir)) / '.config' / 'config.ini'
+        monkeypatch.setattr('nebu.config.CONFIG_FILE_LOC', loc)
+        monkeypatch.setattr('os.environ', {})
+
+        settings = discover_settings()
+
+        expected_settings = {
+            '_config_file': loc,
+            'environs': {
+                'dev': {'url': 'https://dev.cnx.org'},
+                'qa': {'url': 'https://qa.cnx.org'},
+                'staging': {'url': 'https://staging.cnx.org'},
+                'prod': {'url': 'https://cnx.org'},
+            },
+        }
+        assert settings == expected_settings
+
+        with loc.open('r') as fb:
+            assert fb.read() == INITIAL_DEFAULT_CONFIG
+
 
 class TestPrepare:
 


### PR DESCRIPTION
Fixes #66 