### PR TITLE
Add pre-commit configuration for IDE agnostic styling checks and correction

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,15 @@
+# See https://pre-commit.com for more information
+# See https://pre-commit.com/hooks.html for more hooks
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v1.2.3
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+      - id: check-added-large-files
+      - id: flake8
+  # - repo: https://github.com/asottile/add-trailing-comma
+  #   rev: v0.6.4
+  #   hooks:
+  #     - id: add-trailing-comma


### PR DESCRIPTION
This puts in a configuration for https://pre-commit.com/. You can use this config by running `pre-commit install` (after pre-commit is installed of course).

I've been using this on Press for several weeks now. It particularly helps prevent the miscellaneous pep8 error from popping up on travis.