### PR TITLE
Add content environs to the default config

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,11 @@
 Change Log
 ==========
 
+5.0.2
+-----
+
+- Add content*.cnx.org environments to the default configuration file.
+
 5.0.1
 -----
 
@@ -31,7 +36,7 @@ Change Log
 
 - Retrieve content from archive, rather than legacy.
 
-- Make the collectiom version required for 
+- Make the collectiom version required for
   ``neb get [env] [colid] [col_version]``.
   See https://github.com/Connexions/nebuchadnezzar/issues/54
 

--- a/nebu/config.py
+++ b/nebu/config.py
@@ -23,6 +23,21 @@ url = https://staging.cnx.org
 
 [environ-prod]
 url = https://cnx.org
+
+[environ-content01]
+url = https://content01.cnx.org
+
+[environ-content02]
+url = https://content02.cnx.org
+
+[environ-content03]
+url = https://content03.cnx.org
+
+[environ-content04]
+url = https://content04.cnx.org
+
+[environ-content05]
+url = https://content05.cnx.org
 """
 
 

--- a/nebu/tests/test_config.py
+++ b/nebu/tests/test_config.py
@@ -73,6 +73,11 @@ class TestDiscoverSettings:
                 'qa': {'url': 'https://qa.cnx.org'},
                 'staging': {'url': 'https://staging.cnx.org'},
                 'prod': {'url': 'https://cnx.org'},
+                'content01': {'url': 'https://content01.cnx.org'},
+                'content02': {'url': 'https://content02.cnx.org'},
+                'content03': {'url': 'https://content03.cnx.org'},
+                'content04': {'url': 'https://content04.cnx.org'},
+                'content05': {'url': 'https://content05.cnx.org'},
             },
         }
         assert settings == expected_settings
@@ -94,6 +99,11 @@ class TestDiscoverSettings:
                 'qa': {'url': 'https://qa.cnx.org'},
                 'staging': {'url': 'https://staging.cnx.org'},
                 'prod': {'url': 'https://cnx.org'},
+                'content01': {'url': 'https://content01.cnx.org'},
+                'content02': {'url': 'https://content02.cnx.org'},
+                'content03': {'url': 'https://content03.cnx.org'},
+                'content04': {'url': 'https://content04.cnx.org'},
+                'content05': {'url': 'https://content05.cnx.org'},
             },
         }
         assert settings == expected_settings


### PR DESCRIPTION
Simply adds the content*.cnx.org environments to the default configuration file.

See also https://trello.com/c/N4CerCBv/