### PR TITLE
Update cnxml for >=2.2.0

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,11 @@
 Change Log
 ==========
 
+5.0.3
+-----
+
+- Update tests to match new error messages from cnxml v2.2.0
+
 5.0.2
 -----
 

--- a/nebu/cli/validate.py
+++ b/nebu/cli/validate.py
@@ -20,7 +20,13 @@ def is_valid(struct):
     cwd = Path('.').resolve()
     for filepath, error_msg in validate_litezip(struct):
         has_errors = True
-        filepath = filepath.relative_to(cwd)
+        try:
+            filepath = filepath.relative_to(cwd)
+        except ValueError as err:
+            if 'does not start with' in str(err):
+                pass
+            else:
+                raise
         logger.error('{}:{}'.format(filepath, error_msg))
     return not has_errors
 

--- a/nebu/tests/cli/test_validate.py
+++ b/nebu/tests/cli/test_validate.py
@@ -49,3 +49,31 @@ class TestValidateCmd:
             assert line in result.output
 
         assert "We've got problems... :(" in result.output
+
+    def test_outside_cwd_invalid_content(self, datadir, monkeypatch, invoker):
+        path = datadir / 'invalid_collection'
+
+        from nebu.cli.main import cli
+        args = ['validate', str(path)]
+        result = invoker(cli, args)
+
+        assert result.exit_code == 0
+
+        expected_output = (
+            'mux:mux is not a valid identifier',
+            ('collection.xml:114:13 -- error: element "cnx:para" not'
+             ' allowed here; expected element "content", "declarations", '
+             '"extensions", "featured-links" or "parameters"'
+             ),
+            ('mux/index.cnxml:61:10 -- error: element "foo" not allowed'
+             ' anywhere; expected element "code", "definition", "div", '
+             '"equation", "example", "exercise", "figure", "list", "media",'
+             ' "note", "para", "preformat", "q:problemset", '
+             '"quote", "rule", "section" or "table"'
+             ),
+        )
+
+        for line in expected_output:
+            assert line in result.output
+
+        assert "We've got problems... :(" in result.output

--- a/nebu/tests/cli/test_validate.py
+++ b/nebu/tests/cli/test_validate.py
@@ -32,13 +32,19 @@ class TestValidateCmd:
         assert result.exit_code == 0
 
         expected_output = (
-            ('collection.xml:114:13 -- error: element "para" from '
-             'namespace "http://cnx.rice.edu/cnxml" not allowed in '
-             'this context'),
             'mux:mux is not a valid identifier',
-            ('mux/index.cnxml:61:10 -- error: unknown element "foo" from '
-             'namespace "http://cnx.rice.edu/cnxml"'),
+            ('collection.xml:114:13 -- error: element "cnx:para" not'
+             ' allowed here; expected element "content", "declarations", '
+             '"extensions", "featured-links" or "parameters"'
+             ),
+            ('mux/index.cnxml:61:10 -- error: element "foo" not allowed'
+             ' anywhere; expected element "code", "definition", "div", '
+             '"equation", "example", "exercise", "figure", "list", "media",'
+             ' "note", "para", "preformat", "q:problemset", '
+             '"quote", "rule", "section" or "table"'
+             ),
         )
+
         for line in expected_output:
             assert line in result.output
 


### PR DESCRIPTION
New cnxml has a newer jing that returns better error messages. This updates those, as well as allowing validation in a directory that is not a child of the current directory. (displaying error messages blew up trying to shorten the path)

requires cnxml >= v2.1.1-1-ge661791