### PR TITLE
Update readme, instruct to install virtualenv

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -25,9 +25,10 @@ Install
 -------
 
 1. Install ``python3`` (on OSX you can run ``brew install python3``)
+#. Install ``virtualenv`` (on OSX you can run ``pip3 install virtualenv``)
 #. Initialize the python virtual environment:
 
-   a. ``virtualenv ./venv/ --python=python3.5``
+   a. ``virtualenv ./venv/``
    #. ``source ./venv/bin/activate``
    #. ``pip3 install --upgrade pip setuptools``
    #. ``python setup.py develop``

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Install
 #. Install ``virtualenv`` (on OSX you can run ``pip3 install virtualenv``)
 #. Initialize the python virtual environment:
 
-   a. ``python3 -m virtualenv env``
+   a. ``virtualenv ./venv/ --python=python3.5``
    #. ``source ./venv/bin/activate``
    #. ``pip3 install --upgrade pip setuptools``
    #. ``python setup.py develop``

--- a/README.rst
+++ b/README.rst
@@ -28,7 +28,7 @@ Install
 #. Install ``virtualenv`` (on OSX you can run ``pip3 install virtualenv``)
 #. Initialize the python virtual environment:
 
-   a. ``virtualenv ./venv/``
+   a. ``python3 -m virtualenv env``
    #. ``source ./venv/bin/activate``
    #. ``pip3 install --upgrade pip setuptools``
    #. ``python setup.py develop``


### PR DESCRIPTION
Update readme.

1. Instruct devs to install `virtualenv`.
~2. Specifying a specific Python version isn't necessary, and if you specify an incorrect version, the `virtualenv` command will fail, so remove it from the README.~