### PR TITLE
fixup to match litezip 1.5

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,11 @@
 Change Log
 ==========
 
+7.0.1
+-----
+
+- fix litezip 1.5 compatability 
+
 7.0.0
 -----
 
@@ -16,6 +21,7 @@ Change Log
 -----
 
 - fixup basic auth header - use library rather than roll our own
+
 6.0.0
 -----
 

--- a/nebu/cli/publish.py
+++ b/nebu/cli/publish.py
@@ -35,14 +35,16 @@ def _publish(base_url, struct, message, username, password):
                 rel_file_path = base_file_path / model.file.name
                 files.append((file, rel_file_path))
                 for resource in model.resources:
-                    files.append((resource, base_file_path / resource.name))
+                    files.append((resource.data,
+                                  base_file_path / resource.filename))
             else:  # Module
                 file = model.file
                 rel_file_path = base_file_path / model.id / model.file.name
                 files.append((file, rel_file_path))
                 for resource in model.resources:
-                    files.append((resource,
-                                  base_file_path / model.id / resource.name))
+                    files.append((resource.data,
+                                  base_file_path /
+                                  model.id / resource.filename))
 
             for file, rel_file_path in files:
                 zb.write(str(file), str(rel_file_path))

--- a/nebu/tests/data/invalid_collection/mux/index.cnxml
+++ b/nebu/tests/data/invalid_collection/mux/index.cnxml
@@ -7,7 +7,7 @@
        Changes to the metadata section in the source will not be saved. -->
   <md:repository>http://cnx.org/content</md:repository>
   <md:content-url>http://cnx.org/content/m42304/latest</md:content-url>
-  <md:content-id>m42304</md:content-id>
+  <md:content-id>mux</md:content-id>
   <md:title>Lab 1-1: 4-Bit Mux and all NAND/NOR Mux</md:title>
   <md:version>1.3</md:version>
   <md:created>2012/01/19 22:11:40 -0600</md:created>

--- a/requirements/main.txt
+++ b/requirements/main.txt
@@ -1,5 +1,5 @@
 click
-cnx-litezip
+cnx-litezip>=1.5.0
 pip
 requests
 setuptools


### PR DESCRIPTION
moving models into litezip was not _quite_ completely compatible w/ the models previously used here
for resources: res.name -> res.filename (as well as where the module id is aquired)