### PR TITLE
Add the staged.cnx.org environment to the default config file

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -2,6 +2,11 @@
 Change Log
 ==========
 
+7.2.1
+-----
+
+- Add staged.cnx.org environments to the default configuration file.
+
 7.2.0
 -----
 

--- a/nebu/config.py
+++ b/nebu/config.py
@@ -38,6 +38,9 @@ url = https://content04.cnx.org
 
 [environ-content05]
 url = https://content05.cnx.org
+
+[environ-staged]
+url = https://staged.cnx.org
 """
 
 

--- a/nebu/tests/test_config.py
+++ b/nebu/tests/test_config.py
@@ -78,6 +78,7 @@ class TestDiscoverSettings:
                 'content03': {'url': 'https://content03.cnx.org'},
                 'content04': {'url': 'https://content04.cnx.org'},
                 'content05': {'url': 'https://content05.cnx.org'},
+                'staged': {'url': 'https://staged.cnx.org'},
             },
         }
         assert settings == expected_settings
@@ -104,6 +105,7 @@ class TestDiscoverSettings:
                 'content03': {'url': 'https://content03.cnx.org'},
                 'content04': {'url': 'https://content04.cnx.org'},
                 'content05': {'url': 'https://content05.cnx.org'},
+                'staged': {'url': 'https://staged.cnx.org'},
             },
         }
         assert settings == expected_settings


### PR DESCRIPTION
This adds the staged.cnx.org environment to the default config. This will be used by cnx-automation test against this environment.